### PR TITLE
FILTER now preceeds INTERFACES. Filter expression will now run on all interfaces

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# FIX: since tshark wont write to a directory that is not owned by the user 
+# FIX: since tshark wont write to a directory that is not owned by the user
 # executing the command
 chown root:root /data
 
@@ -13,9 +13,9 @@ do
 done
 
 # -b filesize:
-#          max file size (creates new file counting up, unit 1 = 1,000 
+#          max file size (creates new file counting up, unit 1 = 1,000
 #          bytes))
-#    files: max number of created files (rotating buffer since files from the 
+#    files: max number of created files (rotating buffer since files from the
 #          beginning are overwritten)
 #    duratioin: number of seconds that a file will be kept before rotating
 # -w writing the raw packets to a file rather than to stdout
@@ -35,4 +35,4 @@ then
   BUFFEROPTS="$BUFFEROPTS -b duration:$DURATION"
 fi
 
-/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $INTERFACES $FILTER
+/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $FILTER $INTERFACES 

--- a/run.sh
+++ b/run.sh
@@ -35,4 +35,4 @@ then
   BUFFEROPTS="$BUFFEROPTS -b duration:$DURATION"
 fi
 
-/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $FILTER $INTERFACES 
+/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" -f "$FILTER" $INTERFACES 


### PR DESCRIPTION
Based on [issue #7](https://github.com/travelping/docker-pcap/issues/7).
New startup command is `/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $FILTER $INTERFACES `.