### PR TITLE
Interval feature branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine
+FROM alpine:edge
 
-RUN apk add --no-cache tshark coreutils
+RUN apk add --no-cache tshark=2.6.2-r0 coreutils
 
 ADD run.sh /run.sh
 
@@ -9,6 +9,7 @@ ENV IFACE="any"
 ENV MAXFILESIZE="1000"
 ENV MAXFILENUM="10"
 ENV FILENAME="dump"
+ENV INTERVAL="30"
 
 USER root:root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 
-RUN apk add --no-cache tshark=2.6.2-r0 coreutils
+RUN apk add --no-cache tshark coreutils
 
 ADD run.sh /run.sh
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TSHARK in a container
 
-This container starts a tshark and safes the captured packages in files. IT 
-uses a ring buffer with a default file size of 1 Gigabyte and a maximum number 
+This container starts a tshark and safes the captured packages in files. IT
+uses a ring buffer with a default file size of 1 Gigabyte and a maximum number
 of files of 10. All files are stored in the `/data` directory.
 
 ## Usage
@@ -22,6 +22,7 @@ These options are configurable:
 | `MAXFILENUM`  |          `10` |
 | `DURATION`    |          `""` |
 | `FILENAME`    |        `dump` |
+| `INTERVAL`    |          `30` |
 
 `IFACE` is the interface tshark should listen on.
 
@@ -33,24 +34,26 @@ be opened. The unit for this is Megabytes (1 Megabyte = 1,000,000 bytes).
 `MAXFILENUM` is the maximum number of files that are opened before tshark
 starts overwriting old files one by one beginning with the first one.
 
-`DURATION` is the maximum number of seconds tshark waits until it begins to 
+`DURATION` is the maximum number of seconds tshark waits until it begins to
 write into the next file.
 
-The `FILENAME` variable sets the filename that is used. The default value is 
-`dump`. A number will be attached to each file (see tshark manpage for more 
-information). To dump on multiple interfaces simply add more interfaces to this 
+The `FILENAME` variable sets the filename that is used. The default value is
+`dump`. A number will be attached to each file (see tshark manpage for more
+information). To dump on multiple interfaces simply add more interfaces to this
 variable seperated by a whitespace (e.g. "eth0 eth1").
 
 Example:
 
 ```
--> % ls -1 dump 
+-> % ls -1 dump
 dump_00164_20180622110637
 dump_00165_20180622110638
 dump_00166_20180622110639
 dump_00167_20180622110640
 dump_00168_20180622110640
 ```
+
+`INTERVAl` uses Wireshark's `Capture output: -b` option. It allows to run "multiple files" mode, which enables to switch between capture files if a condition is met. The value defined in `interval` will execute a switch to the next capture file whenever the time is an *exact multiple* of `value` seconds.
 
 To extract the files, containing the captured packages, from the container to
 the host, the simplest way is to mount a host folder over the data directory
@@ -68,13 +71,13 @@ option to read captured raw packages from a file.
 
 ### Display Filters
 
-Since `tshark` does not allow for wireshark like filters to be applied to a 
-capture stream. And the functionality of piping to a `tshark` and than applying 
-a read filter is also broken (see 
-https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=2234), applying wireshark 
+Since `tshark` does not allow for wireshark like filters to be applied to a
+capture stream. And the functionality of piping to a `tshark` and than applying
+a read filter is also broken (see
+https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=2234), applying wireshark
 like filters needs to be done in a second filter pass.
 
-This can be done with a local installed instance of `tshark` or using the 
+This can be done with a local installed instance of `tshark` or using the
 `tshark` provided by the docker-pcap container:
 
 ```

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# FIX: since tshark wont write to a directory that is not owned by the user 
+# FIX: since tshark wont write to a directory that is not owned by the user
 # executing the command
 chown root:root /data
 
@@ -13,12 +13,13 @@ do
 done
 
 # -b filesize:
-#          max file size (creates new file counting up, unit 1 = 1,000 
+#          max file size (creates new file counting up, unit 1 = 1,000
 #          bytes))
-#    files: max number of created files (rotating buffer since files from the 
+#    files: max number of created files (rotating buffer since files from the
 #          beginning are overwritten)
-#    duratioin: number of seconds that a file will be kept before rotating
+#    duration: number of seconds that a file will be kept before rotating
 # -w writing the raw packets to a file rather than to stdout
+#    interval: number to create time intervals of value secs
 
 if [ -n "$MAXFILESIZE" ];
 then
@@ -35,4 +36,9 @@ then
   BUFFEROPTS="$BUFFEROPTS -b duration:$DURATION"
 fi
 
-/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $INTERFACES $FILTER
+if [ -n "$INTERVAL" ];
+then
+  BUFFEROPTS="$BUFFEROPTS -b interval:$INTERVAL"
+fi
+
+/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $FILTER $INTERFACES

--- a/run.sh
+++ b/run.sh
@@ -41,4 +41,4 @@ then
   BUFFEROPTS="$BUFFEROPTS -b interval:$INTERVAL"
 fi
 
-/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $FILTER $INTERFACES
+/usr/bin/tshark $BUFFEROPTS -w "/data/$FILENAME" $INTERFACES $FILTER


### PR DESCRIPTION
Added interval option, ``alpine` version has to be changed to branch edge to support `tshark:2.4.8+`. 
Based on [issue #8](https://github.com/travelping/docker-pcap/issues/8).

- Added ENV for the interval, defaults to 30 seconds.
- Updated README to explain usage.