### PR TITLE
Switch to tshark-4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## NEXT- Feature:
 
-- Use tshark-3.4.9
-- Use alpine:3.15 as base image
+- Use tshark-4.0
+- Use alpine:3.17 as base image
 - Change the defaults for
   * FILTER to "icmp" (prevents unintentional capture of all traffic)
   * DURATION to 600 seconds (prevents unintentional infinity captures)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.15
+FROM alpine:3.17
 
-RUN apk add --no-cache \
+RUN apk update && apk add --no-cache \
         coreutils \
-        'tshark=3.4.9-r0'
+        'tshark=4.0.1-r0'
 
 ADD run.sh /run.sh
 


### PR DESCRIPTION
This commit uses tshark-4.0.1 as the current binary.

In addition, the base image is switched to alpine:3.17 - this addresses a bunch of CVEs related to alpinelinux:3.x