### PR TITLE
Fix the FORMAT option behavior

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -48,9 +48,9 @@ then
 fi
 
 PCAPNG=""
-if [ "$FORMAT" = "pcapng" ];
+if [ "$FORMAT" = "pcap" ];
 then
-  PCAPNG="-n"
+  PCAPNG="-P"
 fi
 
 /usr/bin/dumpcap $PCAPNG $BUFFEROPTS -w "/data/$FILENAME" -f "$FILTER" $INTERFACES $SNAPLENGTH


### PR DESCRIPTION
pcapng is the default file format. If we want to use pcap - "-P" must be used