### PR TITLE
Remove pre-defined capabilities on dumpcap binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.22
 
-RUN apk update && apk upgrade --no-cache && \
-    apk add --no-cache coreutils tshark=4.4.6-r0
+RUN apk add -U --no-cache coreutils libcap-setcap tshark=4.4.6-r0 && \
+    setcap cap_net_raw+eip /usr/bin/dumpcap
 
 ADD run.sh /run.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.22
 
 RUN apk add -U --no-cache coreutils libcap-setcap tshark=4.4.6-r0 && \
-    setcap cap_net_raw+eip /usr/bin/dumpcap
+    setcap cap_net_raw+eip /usr/bin/dumpcap && \
+    adduser pcap -u 65532 -h /dev/null -G wireshark -D -H
 
 ADD run.sh /run.sh
 
@@ -14,8 +15,8 @@ ENV FILENAME="dump"
 ENV FORMAT="pcapng"
 ENV SNAPLENGTH=""
 
-USER root:root
+RUN mkdir /data && chown 65532:101 /data
 
-RUN mkdir /data
+USER 65532:101
 
 CMD [ "/bin/sh", "-c", "/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ maximum number of files of 10. All files are stored in the `/data` directory.
 ## Usage
 
 For the container to be able to capture packets on any interface of the host
-system `--net=host --cap-add NET_ADMIN` needs to be passed to the docker run command.
+system `--net=host --cap-add NET_RAW` needs to be passed to the docker run command.
 
 Environment variables can be overwritten using the `-e` option of the `docker
 run` command.
@@ -59,15 +59,11 @@ truncated by accident.
 `PROMISCUOUS_MODE` defines if the given interface(s) are put into promiscous
 mode or not. If set to `"yes"`, promiscous mode is used for the interfaces.
 Default is: "no", interfaces are _not_ put into promiscous mode.
+In case of `PROMISCUOUS_MODE` is required, the container needs also to run
+with `NET_ADMIN` capabilities (e.g., `docker run --cap-add NET_ADMIN ...`) and
+also as `root` (e.g., `docker run --user root:root ...`).
 
-Example:
-
-    $> ls -1 dump
-    dump_00164_20180622110637
-    dump_00165_20180622110638
-    dump_00166_20180622110639
-    dump_00167_20180622110640
-    dump_00168_20180622110640
+## Examples
 
 To extract the files, containing the captured packages, from the container to
 the host, the simplest way is to mount a host folder over the data directory
@@ -75,8 +71,10 @@ using the `-v` option of the `docker run` command.
 
 **Example:**
 
-    $> docker run --cap-add NET_ADMIN --net=host -e IFACE="enp3s0f1" -e FILTER="tcp port 80" -v \
-        $PWD/dump:/data --rm -ti travelping/pcap
+    $> docker run --cap-add NET_RAW --net=host      \
+        -e IFACE="enp3s0f1"                         \
+        -e FILTER="tcp port 80"                     \
+        -v $PWD/dump:/data --rm -ti travelping/pcap
 
 After the packages are captured, they can be evaluated using tcpdumps `-r`
 option to read captured raw packages from a file.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ also as `root` (e.g., `docker run --user root:root ...`).
 
 ## Examples
 
-To extract the files, containing the captured packages, from the container to
+To extract the files, containing the captured packets, from the container to
 the host, the simplest way is to mount a host folder over the data directory
 using the `-v` option of the `docker run` command.
 
@@ -76,22 +76,19 @@ using the `-v` option of the `docker run` command.
         -e FILTER="tcp port 80"                     \
         -v $PWD/dump:/data --rm -ti travelping/pcap
 
-After the packages are captured, they can be evaluated using tcpdumps `-r`
-option to read captured raw packages from a file.
+After the packets are captured, they can be evaluated using tcpdumps `-r`
+option to read captured raw packets from a file.
 
 ### Display Filters
 
-`tshark` does not allow for wireshark like filters to be applied to a capture
+`dumpcap` does not allow for wireshark like filters to be applied to a capture
 stream. In addition, the functionality of piping to `tshark` and than applying
 a read filter is also [broken][2]. As a result, applying wireshark like
 filters must be done in a second filter pass.
 
-This can be done with a local installed instance of `tshark` or using the
-`tshark` provided by the docker-pcap container:
+This can be done with a local installed instance of `tshark`:
 
-    $> docker run --net=host -v $PWD/dump:/data --rm -ti travelping/pcap /bin/sh
-    / # tshark -r /path/to/file -Y <filter>
-
+    $> tshark -r /path/to/file -Y <filter>
 
 [1]: https://www.wireshark.org/docs/man-pages/dumpcap.html
 [2]: https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=2234


### PR DESCRIPTION
`dumpcap` is the capture engine in the pcap-container. Upstream laid out guidelines to operate `dumpcap` in a secure fashion with the least amount of permissions needed:

https://wiki.wireshark.org/CaptureSetup/CapturePrivileges#Limiting_capture_permission_to_only_one_group

In the section "Setting network privileges for dumpcap if your kernel and file system support file capabilities" upstream envisions to put capabilities to the `dumpcap` binary itself:

   setcap cap_net_raw,cap_net_admin+eip /usr/sbin/dumpcap

Once the `dumpcap` binary received this treatment, the following observation can be made when running an container without any special capabilities:

    / # dumpcap -h
    /bin/sh: dumpcap: Operation not permitted

This can be fixed by running the container with additional capabilities:

    $> docker run -it --rm --cap-add NET_ADMIN alpine:3.22
    / # dumpcap -h
    ...

capabilities(7) documents the purpose of CAP_NET_ADMIN:

    Perform various network-related operations:
    * interface configuration;
    * administration of IP firewall, masquerading, and
    * accounting;
    * modify routing tables;
    * bind to any address for transparent proxying;
    * set type-of-service (TOS);
    * clear driver statistics;
    * set promiscuous mode;
    * enabling multicasting;
    * use setsockopt(2) to set the following socket options: SO_DEBUG, SO_MARK, SO_PRIORITY (for a priority outside the range 0 to 6), SO_RCVBUFFORCE, and SO_SNDBUFFORCE.

CAP_NET_RAW is described as:

    * Use RAW and PACKET sockets;
    * bind to any address for transparent proxying.

Neither of these use case play a role in the regular use of `dumpcap` _except_ of promiscuous mode.

AlpineLinux made a decision in 2019 to follow the guidelines of Wireshark and enforce the capabilities onto the produced binary of `dumpcap` (Commit: 25292898fde6d5aa8791d9411b904c3a3b408c06, see [2], [3]). As a consequence, a container must be started with NET_ADMIN capabilities, indepedendent of the use of promiscuous mode or not.

This commit removes the capabilities on the `dumpcap` binary and thus give the user of the pcap container the choice of running it either with appropriate capabilities to operate in promiscous mode or run it without any special capabilties and still allow to capture traffic.

[1]: https://www.man7.org/linux/man-pages/man7/capabilities.7.html
[2]: https://gitlab.alpinelinux.org/alpine/aports/-/commit/25292898fde6d5aa8791d9411b904c3a3b408c06
[3]: https://gitlab.alpinelinux.org/alpine/aports/-/blob/25292898fde6d5aa8791d9411b904c3a3b408c06/community/wireshark/APKBUILD#L223-231