### PR TITLE
Upgrade to tshark:4.6.1; alpine:3.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## v1.4.2
+
+- use tshark in version `4.6.1-r0`
+- use alpine:3.23.3 as base image
+
 ## v1.4.1
 
 - Use tshark in version `4.4.7-r0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,19 @@
-FROM alpine:3.22.1
+FROM alpine:3.23.3
 
-RUN apk add -U --no-cache coreutils libcap-setcap tshark=4.4.7-r0 && \
+ARG VERSION=1.4.2
+
+## https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md
+LABEL org.opencontainers.image.url="https://github.com/travelping/docker-pcap"
+LABEL org.opencontainers.image.source="https://github.com/travelping/docker-pcap"
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.vendor="Travelping GmbH"
+LABEL org.opencontainers.image.title="pcap-$VERSION"
+LABEL org.opencontainers.image.description="pcap - capture network traffic"
+
+RUN apk add -U --no-cache \
+    coreutils \
+    libcap-setcap \
+    tshark=4.6.1-r0 && \
     setcap cap_net_raw+eip /usr/bin/dumpcap && \
     adduser pcap -u 65532 -h /dev/null -G wireshark -D -H
 


### PR DESCRIPTION
This PR addresses all the following CVEs within container image pcap:v1.4.1:

    busybox@1.37.0-r18          CVE-2024-58251  MEDIUM
    busybox@1.37.0-r18          CVE-2025-46394  LOW
    busybox-binsh@1.37.0-r18    CVE-2024-58251  MEDIUM
    busybox-binsh@1.37.0-r18    CVE-2025-46394  LOW
    c-ares@1.34.5-r0            CVE-2025-62408  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-15467  CRITICAL
    libcrypto3@3.5.1-r0         CVE-2025-69419  HIGH
    libcrypto3@3.5.1-r0         CVE-2025-69421  HIGH
    libcrypto3@3.5.1-r0         CVE-2025-11187  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-15468  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-15469  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-66199  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-68160  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-69418  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-69420  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-9230   MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-9231   MEDIUM
    libcrypto3@3.5.1-r0         CVE-2026-22795  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2026-22796  MEDIUM
    libcrypto3@3.5.1-r0         CVE-2025-9232   LOW
    libssl3@3.5.1-r0            CVE-2025-15467  CRITICAL
    libssl3@3.5.1-r0            CVE-2025-69419  HIGH
    libssl3@3.5.1-r0            CVE-2025-69421  HIGH
    libssl3@3.5.1-r0            CVE-2025-11187  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-15468  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-15469  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-66199  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-68160  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-69418  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-69420  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-9230   MEDIUM
    libssl3@3.5.1-r0            CVE-2025-9231   MEDIUM
    libssl3@3.5.1-r0            CVE-2026-22795  MEDIUM
    libssl3@3.5.1-r0            CVE-2026-22796  MEDIUM
    libssl3@3.5.1-r0            CVE-2025-9232   LOW
    libtasn1@4.20.0-r0          CVE-2025-13151  MEDIUM
    libxml2@2.13.8-r0           CVE-2025-49794  CRITICAL
    libxml2@2.13.8-r0           CVE-2025-49796  CRITICAL
    libxml2@2.13.8-r0           CVE-2025-49795  HIGH
    libxml2@2.13.8-r0           CVE-2025-6021   HIGH
    libxml2@2.13.8-r0           CVE-2025-6170   LOW
    pcre2@10.43-r1              CVE-2025-58050  CRITICAL
    ssl_client@1.37.0-r18       CVE-2024-58251  MEDIUM
    ssl_client@1.37.0-r18       CVE-2025-46394  LOW