### PR TITLE
Chore: pin GitHub actions

### DIFF
--- a/.github/workflows/cennso-release.yaml
+++ b/.github/workflows/cennso-release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -31,7 +31,7 @@ jobs:
             prefix=
             suffix=
       - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/cennso-release.yaml
+++ b/.github/workflows/cennso-release.yaml
@@ -9,18 +9,18 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ secrets.CUR_REGISTRY_DOMAIN }}
           username: ${{ secrets.CUR_REGISTRY_USERNAME }}
           password: ${{ secrets.CUR_REGISTRY_PASSWORD }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ${{ secrets.CUR_REGISTRY_DOMAIN }}/${{ secrets.CUR_PROJECT_NAME }}
@@ -31,7 +31,7 @@ jobs:
             prefix=
             suffix=
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Github actions are code someone else controls and provides. Since that code has then
access to not the repository where the action itself is running, but also to certain
external systems like container registries etc (see "NPM supply chain attack 2025-09" etc).

This PR pins the used Github actions to specific versions and thus reduce the chance of
a malicious attack. In addition, the Github actions where upgraded to the latest available
version.